### PR TITLE
A new alternative mode to improve flying experience without overpowering the mod

### DIFF
--- a/src/main/java/me/paulf/wings/server/config/ConfigWingSettings.java
+++ b/src/main/java/me/paulf/wings/server/config/ConfigWingSettings.java
@@ -34,17 +34,23 @@ public final class ConfigWingSettings implements WingSettings {
 	@Config.RangeInt(min = 0, max = Short.MAX_VALUE)
 	public int itemDurability;
 
+	//added an alternative mode which drains minerals instead of food
+	@Deprecated
+	@Config.LangKey("config.wings.items.settings.alternativeMode")
+	public boolean alternativeMode;
+
 	ConfigWingSettings(ResourceLocation key, int itemDurability) {
-		this(key, 7, 0.001D, 2, 0.08D, itemDurability);
+		this(key, 7, 0.001D, 2, 0.08D, itemDurability, false);
 	}
 
-	private ConfigWingSettings(ResourceLocation key, int requiredFlightSatiation, double flyingExertion, int requiredLandSatiation, double landingExertion, int itemDurability) {
+	private ConfigWingSettings(ResourceLocation key, int requiredFlightSatiation, double flyingExertion, int requiredLandSatiation, double landingExertion, int itemDurability, boolean alternativeMode) {
 		this.key = key;
 		this.requiredFlightSatiation = requiredFlightSatiation;
 		this.flyingExertion = flyingExertion;
 		this.requiredLandSatiation = requiredLandSatiation;
 		this.landingExertion = landingExertion;
 		this.itemDurability = itemDurability;
+		this.alternativeMode = alternativeMode;
 	}
 
 	public ResourceLocation getKey() {
@@ -76,7 +82,12 @@ public final class ConfigWingSettings implements WingSettings {
 		return itemDurability;
 	}
 
+	@Override
+	public boolean getAlternativeMode() {
+		return alternativeMode;
+	}
+
 	public WingSettings toImmutable() {
-		return ImmutableWingSettings.of(getRequiredFlightSatiation(), getFlyingExertion(), getRequiredLandSatiation(), getLandingExertion(), getItemDurability());
+		return ImmutableWingSettings.of(getRequiredFlightSatiation(), getFlyingExertion(), getRequiredLandSatiation(), getLandingExertion(), getItemDurability(), getAlternativeMode());
 	}
 }

--- a/src/main/java/me/paulf/wings/server/item/ImmutableWingSettings.java
+++ b/src/main/java/me/paulf/wings/server/item/ImmutableWingSettings.java
@@ -11,12 +11,15 @@ public final class ImmutableWingSettings implements WingSettings {
 
 	private final int itemDurability;
 
-	private ImmutableWingSettings(int requiredFlightSatiation, float flyingExertion, int requiredLandSatiation, float landingExertion, int itemDurability) {
+	private final boolean alternativeMode;
+
+	private ImmutableWingSettings(int requiredFlightSatiation, float flyingExertion, int requiredLandSatiation, float landingExertion, int itemDurability, boolean alternativeMode) {
 		this.requiredFlightSatiation = requiredFlightSatiation;
 		this.flyingExertion = flyingExertion;
 		this.requiredLandSatiation = requiredLandSatiation;
 		this.landingExertion = landingExertion;
 		this.itemDurability = itemDurability;
+		this.alternativeMode = alternativeMode;
 	}
 
 	@Override
@@ -44,7 +47,12 @@ public final class ImmutableWingSettings implements WingSettings {
 		return itemDurability;
 	}
 
-	public static ImmutableWingSettings of(int requiredFlightSatiation, float flyingExertion, int requiredLandSatiation, float landingExertion, int durability) {
-		return new ImmutableWingSettings(requiredFlightSatiation, flyingExertion, requiredLandSatiation, landingExertion, durability);
+	@Override
+	public boolean getAlternativeMode() {
+		return alternativeMode;
+	}
+
+	public static ImmutableWingSettings of(int requiredFlightSatiation, float flyingExertion, int requiredLandSatiation, float landingExertion, int durability, boolean alternativeMode) {
+		return new ImmutableWingSettings(requiredFlightSatiation, flyingExertion, requiredLandSatiation, landingExertion, durability, alternativeMode);
 	}
 }

--- a/src/main/java/me/paulf/wings/server/item/ItemWings.java
+++ b/src/main/java/me/paulf/wings/server/item/ItemWings.java
@@ -125,13 +125,13 @@ public final class ItemWings extends Item {
 					private static final int DAMAGE_RATE_ALTERNATIVE = 1;
 					//set repair value of minerals
 					private static final int REPAIR_FAIRY_DUST = 160;
-					private static final int REPAIR_AMETHYST = 1080;
+					private static final int REPAIR_AMETHYST = 2400;
 
 					private int flightTime;
 
 					//function for repair
 					public void repairStack(EntityPlayer player, ItemStack stack, Item item, int repair) {
-						if (stack.getItemDamage() >= repair) {
+						if ((stack.getItemDamage() >= repair)||(stack.getItemDamage() >= stack.getMaxDamage() - 10)) {
 							if (player.inventory.hasItemStack(new ItemStack(item))) {
 								int slot = player.inventory.getSlotFor(new ItemStack(item));
 								ItemStack itemStack = player.inventory.getStackInSlot(slot);

--- a/src/main/java/me/paulf/wings/server/item/ItemWings.java
+++ b/src/main/java/me/paulf/wings/server/item/ItemWings.java
@@ -31,6 +31,7 @@ public final class ItemWings extends Item {
 
 	private WingSettings settings;
 
+	//factor of exhaustion when in alternative mode
 	private static final float EXHAUSTION_ALTERNATIVE_FACTOR = 0.2F;
 
 	private ItemWings(ImmutableSet<EnumEnchantmentType> allowedEnchantmentTypes, Consumer<CapabilityProviders.CompositeBuilder> capabilities, WingSettings settings) {
@@ -133,7 +134,7 @@ public final class ItemWings extends Item {
 					public void repairStack(EntityPlayer player, ItemStack stack, Item item, int repair) {
 						if ((stack.getItemDamage() >= repair)||(stack.getItemDamage() >= stack.getMaxDamage() - 10)) {
 							if (player.inventory.hasItemStack(new ItemStack(item))) {
-								int slot = player.inventory.getSlotFor(new ItemStack(item));
+								int slot = player.inventory.findSlotMatchingUnusedItem(new ItemStack(item));
 								ItemStack itemStack = player.inventory.getStackInSlot(slot);
 								ItemStack updateItemStack = player.inventory.decrStackSize(slot, itemStack.getCount() - 1);
 								player.inventory.setInventorySlotContents(slot, updateItemStack);

--- a/src/main/java/me/paulf/wings/server/item/WingSettings.java
+++ b/src/main/java/me/paulf/wings/server/item/WingSettings.java
@@ -10,4 +10,6 @@ public interface WingSettings {
 	float getLandingExertion();
 
 	int getItemDurability();
+
+	boolean getAlternativeMode();
 }

--- a/src/main/java/me/paulf/wings/server/net/clientbound/MessageSetWingSettings.java
+++ b/src/main/java/me/paulf/wings/server/net/clientbound/MessageSetWingSettings.java
@@ -35,6 +35,7 @@ public final class MessageSetWingSettings extends Message {
 			buf.writeInt(value.getRequiredLandSatiation());
 			buf.writeFloat(value.getLandingExertion());
 			buf.writeShort(value.getItemDurability());
+			buf.writeBoolean(value.getAlternativeMode());
 		}
 	}
 
@@ -49,7 +50,8 @@ public final class MessageSetWingSettings extends Message {
 					buf.readFloat(),
 					buf.readInt(),
 					buf.readFloat(),
-					buf.readShort()
+					buf.readShort(),
+					buf.readBoolean()
 				)
 			);
 		}


### PR DESCRIPTION
Yeah, from the issue.

Added a new mode.
Implemented the mode into config of each kind of wings (failed to make it global, due to the lack of knowledge as well)
:(
In the new mode the wings will exhaust player at the rate of 1/5.
But they will get damaged 20 times faster.
However, they can draw minerals from player's inventory to repair themselves automatically.
A fairy dust can support 8 seconds of flying.
A amethyst can support 120 seconds of flying.
The three tiers of wings can fly for 48, 96, 144 seconds without repair.